### PR TITLE
chore(commands): removed command fix tsc errors.

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -21,12 +21,7 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
-    "commands": [
-      {
-        "command": "test-extension4.helloWorld",
-        "title": "stackwise: Fix tsc errors"
-      }
-    ],
+    "commands": [],
     "views": {}
   },
   "scripts": {


### PR DESCRIPTION
### Summary
- Removed the command `fix tsc errors`
- Issue: https://github.com/stackwiseai/stackwise/issues/47